### PR TITLE
Implement functions to get publisher and subcription informations like QoS policies from topic name

### DIFF
--- a/rclpy/CMakeLists.txt
+++ b/rclpy/CMakeLists.txt
@@ -209,6 +209,7 @@ if(BUILD_TESTING)
     test/test_time.py
     test/test_timer.py
     test/test_topic_or_service_is_hidden.py
+    test/test_topic_endpoint_info.py
     test/test_utilities.py
     test/test_validate_full_topic_name.py
     test/test_validate_namespace.py

--- a/rclpy/rclpy/qos.py
+++ b/rclpy/rclpy/qos.py
@@ -276,6 +276,8 @@ class HistoryPolicy(QoSPolicyEnum):
     KEEP_LAST = RMW_QOS_POLICY_HISTORY_KEEP_LAST
     RMW_QOS_POLICY_HISTORY_KEEP_ALL = 2
     KEEP_ALL = RMW_QOS_POLICY_HISTORY_KEEP_ALL
+    RMW_QOS_POLICY_HISTORY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_HISTORY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -295,6 +297,8 @@ class ReliabilityPolicy(QoSPolicyEnum):
     RELIABLE = RMW_QOS_POLICY_RELIABILITY_RELIABLE
     RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT = 2
     BEST_EFFORT = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT
+    RMW_QOS_POLICY_RELIABILITY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_RELIABILITY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -314,6 +318,8 @@ class DurabilityPolicy(QoSPolicyEnum):
     TRANSIENT_LOCAL = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL
     RMW_QOS_POLICY_DURABILITY_VOLATILE = 2
     VOLATILE = RMW_QOS_POLICY_DURABILITY_VOLATILE
+    RMW_QOS_POLICY_DURABILITY_UNKNOWN = 3
+    UNKNOWN = RMW_QOS_POLICY_DURABILITY_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
@@ -335,11 +341,15 @@ class LivelinessPolicy(QoSPolicyEnum):
     MANUAL_BY_NODE = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE
     RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC = 3
     MANUAL_BY_TOPIC = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC
+    RMW_QOS_POLICY_LIVELINESS_UNKNOWN = 4
+    UNKNOWN = RMW_QOS_POLICY_LIVELINESS_UNKNOWN
 
 
 # Alias with the old name, for retrocompatibility
 QoSLivelinessPolicy = LivelinessPolicy
 
+qos_profile_unknown = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
+    'qos_profile_unknown'))
 qos_profile_system_default = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_system_default'))
 qos_profile_sensor_data = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
@@ -350,11 +360,12 @@ qos_profile_parameters = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_parameters'))
 qos_profile_parameter_events = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile(
     'qos_profile_parameter_events'))
-qos_profile_action_status_default = QoSProfile(
-    **_rclpy_action.rclpy_action_get_rmw_qos_profile('rcl_action_qos_profile_status_default'))
+qos_profile_action_status_default = QoSProfile(**_rclpy_action.rclpy_action_get_rmw_qos_profile(
+    'rcl_action_qos_profile_status_default'))
 
 
 class QoSPresetProfiles(Enum):
+    UNKNOWN = qos_profile_unknown
     SYSTEM_DEFAULT = qos_profile_system_default
     SENSOR_DATA = qos_profile_sensor_data
     SERVICES_DEFAULT = qos_profile_services_default

--- a/rclpy/rclpy/topic_endpoint_info.py
+++ b/rclpy/rclpy/topic_endpoint_info.py
@@ -1,0 +1,174 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import IntEnum
+
+from rclpy.qos import QoSPresetProfiles, QoSProfile
+
+
+class TopicEndpointTypeEnum(IntEnum):
+    """
+    Enum for possible types of topic endpoints.
+
+    This enum matches the one defined in rmw/types.h
+    """
+
+    INVALID = 0
+    PUBLISHER = 1
+    SUBSCRIPTION = 2
+
+
+class TopicEndpointInfo:
+    """Information on a topic endpoint."""
+
+    __slots__ = [
+        '_node_name',
+        '_node_namespace',
+        '_topic_type',
+        '_endpoint_type',
+        '_endpoint_gid',
+        '_qos_profile'
+    ]
+
+    def __init__(self, **kwargs):
+        assert all('_' + key in self.__slots__ for key in kwargs.keys()), \
+            'Invalid arguments passed to constructor: %r' % kwargs.keys()
+
+        self.node_name = kwargs.get('node_name', '')
+        self.node_namespace = kwargs.get('node_namespace', '')
+        self.topic_type = kwargs.get('topic_type', '')
+        self.endpoint_type = kwargs.get('endpoint_type', TopicEndpointTypeEnum.INVALID)
+        self.endpoint_gid = kwargs.get('endpoint_gid', [])
+        self.qos_profile = kwargs.get('qos_profile', QoSPresetProfiles.UNKNOWN.value)
+
+    @property
+    def node_name(self):
+        """
+        Get field 'node_name'.
+
+        :returns: node_name attribute
+        :rtype: str
+        """
+        return self._node_name
+
+    @node_name.setter
+    def node_name(self, value):
+        assert isinstance(value, str)
+        self._node_name = value
+
+    @property
+    def node_namespace(self):
+        """
+        Get field 'node_namespace'.
+
+        :returns: node_namespace attribute
+        :rtype: str
+        """
+        return self._node_namespace
+
+    @node_namespace.setter
+    def node_namespace(self, value):
+        assert isinstance(value, str)
+        self._node_namespace = value
+
+    @property
+    def topic_type(self):
+        """
+        Get field 'topic_type'.
+
+        :returns: topic_type attribute
+        :rtype: str
+        """
+        return self._topic_type
+
+    @topic_type.setter
+    def topic_type(self, value):
+        assert isinstance(value, str)
+        self._topic_type = value
+
+    @property
+    def endpoint_type(self):
+        """
+        Get field 'endpoint_type'.
+
+        :returns: endpoint_type attribute
+        :rtype: TopicEndpointTypeEnum
+        """
+        return self._endpoint_type
+
+    @endpoint_type.setter
+    def endpoint_type(self, value):
+        if isinstance(value, TopicEndpointTypeEnum):
+            self._endpoint_type = value
+        elif isinstance(value, int):
+            self._endpoint_type = TopicEndpointTypeEnum(value)
+        else:
+            assert False
+
+    @property
+    def endpoint_gid(self):
+        """
+        Get field 'endpoint_gid'.
+
+        :returns: endpoint_gid attribute
+        :rtype: list
+        """
+        return self._endpoint_gid
+
+    @endpoint_gid.setter
+    def endpoint_gid(self, value):
+        assert all(isinstance(x, int) for x in value)
+        self._endpoint_gid = value
+
+    @property
+    def qos_profile(self):
+        """
+        Get field 'qos_profile'.
+
+        :returns: qos_profile attribute
+        :rtype: QoSProfile
+        """
+        return self._qos_profile
+
+    @qos_profile.setter
+    def qos_profile(self, value):
+        if isinstance(value, QoSProfile):
+            self._qos_profile = value
+        elif isinstance(value, dict):
+            self._qos_profile = QoSProfile(**value)
+        else:
+            assert False
+
+    def __eq__(self, other):
+        if not isinstance(other, TopicEndpointInfo):
+            return False
+        return all(
+            self.__getattribute__(slot) == other.__getattribute__(slot)
+            for slot in self.__slots__)
+
+    def __str__(self):
+        result = 'Node name: %s\n' % self.node_name
+        result += 'Node namespace: %s\n' % self.node_namespace
+        result += 'Topic type: %s\n' % self.topic_type
+        result += 'Endpoint type: %s\n' % self.endpoint_type.name
+        result += 'GID: %s\n' % '.'.join(format(x, '02x') for x in self.endpoint_gid)
+        result += 'QoS profile:\n'
+        result += '  Reliability: %s\n' % self.qos_profile.reliability.name
+        result += '  Durability: %s\n' % self.qos_profile.durability.name
+        result += '  Lifespan: %d nanoseconds\n' % self.qos_profile.lifespan.nanoseconds
+        result += '  Deadline: %d nanoseconds\n' % self.qos_profile.deadline.nanoseconds
+        result += '  Liveliness: %s\n' % self.qos_profile.liveliness.name
+        result += '  Liveliness lease duration: %d nanoseconds' % \
+            self.qos_profile.liveliness_lease_duration.nanoseconds
+        return result

--- a/rclpy/src/rclpy_common/include/rclpy_common/common.h
+++ b/rclpy/src/rclpy_common/include/rclpy_common/common.h
@@ -132,4 +132,13 @@ RCLPY_COMMON_PUBLIC
 PyObject *
 rclpy_convert_to_py(void * message, PyObject * pyclass);
 
+/// Convert a C rmw_topic_endpoint_info_array_t into a Python list.
+/**
+ * \param[in] info_array a pointer to a rmw_topic_endpoint_info_array_t
+ * \return Python list
+ */
+RCLPY_COMMON_PUBLIC
+PyObject *
+rclpy_convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * info_array);
+
 #endif  // RCLPY_COMMON__COMMON_H_

--- a/rclpy/src/rclpy_common/src/common.c
+++ b/rclpy/src/rclpy_common/src/common.c
@@ -358,3 +358,104 @@ rclpy_convert_to_py(void * message, PyObject * pyclass)
   }
   return convert(message);
 }
+
+PyObject *
+_rclpy_convert_to_py_topic_endpoint_info(const rmw_topic_endpoint_info_t * topic_endpoint_info)
+{
+  PyObject * py_node_name = NULL;
+  PyObject * py_node_namespace = NULL;
+  PyObject * py_topic_type = NULL;
+  PyObject * py_endpoint_type = NULL;
+  PyObject * py_endpoint_gid = NULL;
+  PyObject * py_qos_profile = NULL;
+  PyObject * py_endpoint_info_dict = NULL;
+
+  py_node_name = PyUnicode_FromString(topic_endpoint_info->node_name);
+  if (!py_node_name) {
+    goto fail;
+  }
+  py_node_namespace = PyUnicode_FromString(topic_endpoint_info->node_namespace);
+  if (!py_node_namespace) {
+    goto fail;
+  }
+  py_topic_type = PyUnicode_FromString(topic_endpoint_info->topic_type);
+  if (!py_topic_type) {
+    goto fail;
+  }
+  py_endpoint_type = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_type);
+  if (!py_endpoint_type) {
+    goto fail;
+  }
+
+  py_endpoint_gid = PyList_New(RMW_GID_STORAGE_SIZE);
+  if (!py_endpoint_gid) {
+    goto fail;
+  }
+  for (int i = 0; i < RMW_GID_STORAGE_SIZE; i++) {
+    PyObject * py_val_at_index = PyLong_FromUnsignedLong(topic_endpoint_info->endpoint_gid[i]);
+    if (!py_val_at_index) {
+      goto fail;
+    }
+    PyList_SET_ITEM(py_endpoint_gid, i, py_val_at_index);
+  }
+
+  py_qos_profile = rclpy_common_convert_to_qos_dict(&topic_endpoint_info->qos_profile);
+  if (!py_qos_profile) {
+    goto fail;
+  }
+
+  // Create dictionary that represents rmw_topic_endpoint_info_t
+  py_endpoint_info_dict = PyDict_New();
+  if (!py_endpoint_info_dict) {
+    goto fail;
+  }
+  // Populate keyword arguments
+  // A success returns 0, and a failure returns -1
+  int set_result = 0;
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "node_name", py_node_name);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "node_namespace", py_node_namespace);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "topic_type", py_topic_type);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "endpoint_type", py_endpoint_type);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "endpoint_gid", py_endpoint_gid);
+  set_result += PyDict_SetItemString(py_endpoint_info_dict, "qos_profile", py_qos_profile);
+  if (set_result != 0) {
+    goto fail;
+  }
+  return py_endpoint_info_dict;
+
+fail:
+  Py_XDECREF(py_node_name);
+  Py_XDECREF(py_node_namespace);
+  Py_XDECREF(py_topic_type);
+  Py_XDECREF(py_endpoint_type);
+  Py_XDECREF(py_endpoint_gid);
+  Py_XDECREF(py_qos_profile);
+  Py_XDECREF(py_endpoint_info_dict);
+  return NULL;
+}
+
+PyObject *
+rclpy_convert_to_py_topic_endpoint_info_list(const rmw_topic_endpoint_info_array_t * info_array)
+{
+  if (!info_array) {
+    return NULL;
+  }
+
+  PyObject * py_info_array = PyList_New(info_array->count);
+  if (!py_info_array) {
+    return NULL;
+  }
+
+  for (size_t i = 0; i < info_array->count; ++i) {
+    rmw_topic_endpoint_info_t topic_endpoint_info = info_array->info_array[i];
+    PyObject * py_endpoint_info_dict = _rclpy_convert_to_py_topic_endpoint_info(
+      &topic_endpoint_info);
+    if (!py_endpoint_info_dict) {
+      Py_DECREF(py_info_array);
+      return NULL;
+    }
+    // add this dict to the list
+    PyList_SET_ITEM(py_info_array, i, py_endpoint_info_dict);
+  }
+  return py_info_array;
+}

--- a/rclpy/test/test_qos.py
+++ b/rclpy/test/test_qos.py
@@ -105,7 +105,9 @@ class TestQosProfile(unittest.TestCase):
 
     def test_policy_short_names(self):
         # Full test on History to show the mechanism works
-        assert QoSHistoryPolicy.short_keys() == ['system_default', 'keep_last', 'keep_all']
+        assert (
+            QoSHistoryPolicy.short_keys() ==
+            ['system_default', 'keep_last', 'keep_all', 'unknown'])
         assert (
             QoSHistoryPolicy.get_from_short_key('system_default') ==
             QoSHistoryPolicy.RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT.value)

--- a/rclpy/test/test_topic_endpoint_info.py
+++ b/rclpy/test/test_topic_endpoint_info.py
@@ -1,0 +1,104 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
+from rclpy.qos import QoSProfile
+from rclpy.topic_endpoint_info import TopicEndpointInfo, TopicEndpointTypeEnum
+
+
+class TestQosProfile(unittest.TestCase):
+
+    def test_node_name_only_constructor(self):
+        test_node_name = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.node_name = test_node_name
+
+        info_from_ctor = TopicEndpointInfo(node_name=test_node_name)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_node_name, info_from_ctor.node_name)
+
+    def test_node_namespace_only_constructor(self):
+        test_node_namespace = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.node_namespace = test_node_namespace
+
+        info_from_ctor = TopicEndpointInfo(node_namespace=test_node_namespace)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_node_namespace, info_from_ctor.node_namespace)
+
+    def test_topic_type_only_constructor(self):
+        test_topic_type = 'test_string'
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.topic_type = test_topic_type
+
+        info_from_ctor = TopicEndpointInfo(topic_type=test_topic_type)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_topic_type, info_from_ctor.topic_type)
+
+    def test_endpoint_type_only_constructor(self):
+        test_endpoint_type = TopicEndpointTypeEnum.SUBSCRIPTION
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.endpoint_type = test_endpoint_type
+
+        info_from_ctor = TopicEndpointInfo(endpoint_type=test_endpoint_type)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_endpoint_type, info_from_ctor.endpoint_type)
+
+    def test_endpoint_gid_only_constructor(self):
+        test_endpoint_gid = [0, 0, 0, 0, 0]
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.endpoint_gid = test_endpoint_gid
+
+        info_from_ctor = TopicEndpointInfo(endpoint_gid=test_endpoint_gid)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_endpoint_gid, info_from_ctor.endpoint_gid)
+
+    def test_qos_profile_only_constructor(self):
+        test_qos_profile = QoSProfile(**_rclpy.rclpy_get_rmw_qos_profile('qos_profile_default'))
+
+        info_for_ref = TopicEndpointInfo()
+        info_for_ref.qos_profile = test_qos_profile
+
+        info_from_ctor = TopicEndpointInfo(qos_profile=test_qos_profile)
+
+        self.assertEqual(info_for_ref, info_from_ctor)
+        self.assertEqual(test_qos_profile, info_from_ctor.qos_profile)
+
+    def test_print(self):
+        actual_info_str = str(TopicEndpointInfo())
+        expected_info_str = 'Node name: \n' \
+            'Node namespace: \n' \
+            'Topic type: \n' \
+            'Endpoint type: INVALID\n' \
+            'GID: \n' \
+            'QoS profile:\n' \
+            '  Reliability: RMW_QOS_POLICY_RELIABILITY_UNKNOWN\n' \
+            '  Durability: RMW_QOS_POLICY_DURABILITY_UNKNOWN\n' \
+            '  Lifespan: 0 nanoseconds\n' \
+            '  Deadline: 0 nanoseconds\n' \
+            '  Liveliness: RMW_QOS_POLICY_LIVELINESS_UNKNOWN\n' \
+            '  Liveliness lease duration: 0 nanoseconds'
+        self.assertEqual(expected_info_str, actual_info_str)


### PR DESCRIPTION
Recreated from original PR: https://github.com/ros2/rclpy/pull/454

**NOTE: DO NOT MERGE until [rmw #186](https://github.com/ros2/rmw/pull/186),  [rmw_implementation #72](https://github.com/ros2/rmw_implementation/pull/72) and [rcl #511](https://github.com/ros2/rcl/pull/511) are merged.**

This PR makes the necessary changes to implement [this](https://github.com/ros2/rmw/issues/151) feature request. The `RCLPY` layer needs to expose functions to the `ros2cli` layer such that `ros2 topic info <topic_name>` can display publisher and subscriptions information fo...